### PR TITLE
Path fix for download_files()

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -289,7 +289,7 @@ download_files <- function(id, path = NULL, private = FALSE, version = NULL) {
   # Find the filename as on the OSF
   if (is.null(path)) {
     file <- res$data$attributes$name
-  } else {
+  } else if (grepl('/$', path)) {
     file <- paste0(path, res$data$attributes$name)
   }
 

--- a/R/files.R
+++ b/R/files.R
@@ -286,7 +286,10 @@ download_files <- function(id, path = NULL, private = FALSE, version = NULL) {
 
   res <- process_json(call)
 
-  # Find the filename as on the OSF
+  # Determine the file name to save the file as.
+  # If no path is provided, use the OSF file name.
+  # If a path is provided, determine if the path is just a folder path or if
+  # the path includes a file name.
   if (is.null(path)) {
     file <- res$data$attributes$name
   } else if (grepl('/$', path)) {

--- a/R/files.R
+++ b/R/files.R
@@ -291,6 +291,8 @@ download_files <- function(id, path = NULL, private = FALSE, version = NULL) {
     file <- res$data$attributes$name
   } else if (grepl('/$', path)) {
     file <- paste0(path, res$data$attributes$name)
+  } else {
+    file <- path
   }
 
   message(paste0('Saving to filename: ', file))

--- a/R/files.R
+++ b/R/files.R
@@ -268,7 +268,7 @@ move_files <- function(
 #' @return Return filepath for easy processing
 #' @examples
 #' \dontrun{
-#' download_file('zevw2', 'test123.md')
+#' download_files('5z2bh', 'public_test_file.csv')
 #' }
 #' @importFrom utils tail
 #' @export

--- a/R/files.R
+++ b/R/files.R
@@ -262,7 +262,7 @@ move_files <- function(
 #'
 #' @param id Specify the node id (osf.io/XXXX)
 #' @param version Specify the OSF version id (string)
-#' @param path Specify path to save file to. If NULL, defaults to OSF filename in \code{\link{tempdir}}
+#' @param path Specify path to save file to. If NULL, defaults to OSF filename in the working directory
 #' @param private Boolean to specify whether file is private
 #'
 #' @return Return filepath for easy processing

--- a/R/files.R
+++ b/R/files.R
@@ -288,10 +288,7 @@ download_files <- function(id, path = NULL, private = FALSE, version = NULL) {
 
   # Find the filename as on the OSF
   if (is.null(path)) {
-    txt <- res$data$attributes$name
-    start <- utils::tail(gregexpr('/', txt)[[1]], 1)
-    end <-  nchar(txt)
-    file <- substr(txt, start + 1, end)
+    file <- res$data$attributes$name
   } else {
     file <- paste0(path, res$data$attributes$name)
   }

--- a/man/download_files.Rd
+++ b/man/download_files.Rd
@@ -9,7 +9,7 @@ download_files(id, path = NULL, private = FALSE, version = NULL)
 \arguments{
 \item{id}{Specify the node id (osf.io/XXXX)}
 
-\item{path}{Specify path to save file to. If NULL, defaults to OSF filename in \code{\link{tempdir}}}
+\item{path}{Specify path to save file to. If NULL, defaults to OSF filename in the working directory}
 
 \item{private}{Boolean to specify whether file is private}
 
@@ -23,6 +23,6 @@ Download files from the OSF
 }
 \examples{
 \dontrun{
-download_file('zevw2', 'test123.md')
+download_files('5z2bh', 'public_test_file.csv')
 }
 }


### PR DESCRIPTION
Hi Chris, 

This should fix the bug in #45. The main change is in how the file name to be saved is determined. It should cover all of the cases brought up in #45 and currently saves files to the working directory using the file name given on the OSF. I've also included a new example in the documentation that uses a public file on a new osfr Demo project on the OSF. 

The project is available at: https://osf.io/m5pds/

Thanks!