### PR TITLE
Using OSF API for `get_files_info()` for GUIDs

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -3,7 +3,7 @@ download_files <- function () {}
 #' Upload a new file to the OSF.
 #'
 #' @param id Parent OSF project (osf.io/xxxxx).
-#' @param path Path to file. 
+#' @param path Path to file.
 #' @param name Name of the uploaded file (if \code{NULL},
 #' current name will be used).
 #'

--- a/R/files.R
+++ b/R/files.R
@@ -348,7 +348,10 @@ get_files_info <- function(id, private = FALSE) {
   url_osf <- construct_link(request = paste0('nodes/', id, '/files/osfstorage/'))
 
   call <- httr::GET(url_osf, config)
-  files <- process_json(call)$data
+
+  # Process the requested JSON
+  res <- process_json(call)
+
   files <- process_files(files)
 
   if (is.null(files)) {

--- a/R/files.R
+++ b/R/files.R
@@ -370,6 +370,7 @@ get_files_info <- function(id, private = FALSE) {
     res <- lapply(files$folder_link[idx], function(href) {
       call <- httr::GET(href, config)
       tmp <- process_json(call)
+      pag_tmp <- process_pagination(tmp, config)
       process_files(tmp)
     })
     files$processed <- TRUE

--- a/R/files.R
+++ b/R/files.R
@@ -328,17 +328,16 @@ get_files_info <- function(id, private = FALSE) {
     do.call(rbind, lapply(files, function(x) {
       data.frame(
         name = fix_null(x$attributes$name),
-        materialized = fix_null(x$attributes$materialized),
+        materialized = fix_null(x$attributes$materialized_path),
         kind = fix_null(x$attributes$kind),
         guid = fix_null(x$attributes$guid), # this isn't populated until it's viewed in OSF
-        resource = fix_null(x$attributes$resource),
         provider = fix_null(x$attributes$provider),
-        content_type = fix_null(x$attributes$contentType), # nolint
-        created_utc = fix_null(x$attributes$created_utc),
-        modified_utc = fix_null(x$attributes$modified_utc),
+        created_utc = fix_null(x$attributes$date_created),
+        modified_utc = fix_null(x$attributes$date_modified),
         downloads = fix_null(x$attributes$extra$downloads),
-        version = fix_null(x$attributes$extra$version),
+        version = fix_null(x$attributes$current_version),
         href = fix_null(x$links$move),
+        folder_link = fix_null(x$relationships$files$links$related$href),
         processed = FALSE,
         stringsAsFactors = FALSE
       )

--- a/R/files.R
+++ b/R/files.R
@@ -371,7 +371,7 @@ get_files_info <- function(id, private = FALSE) {
       call <- httr::GET(href, config)
       tmp <- process_json(call)
       pag_tmp <- process_pagination(tmp, config)
-      process_files(tmp)
+      process_files(pag_tmp)
     })
     files$processed <- TRUE
     files <- do.call(rbind, c(list(files), res))

--- a/R/files.R
+++ b/R/files.R
@@ -352,6 +352,9 @@ get_files_info <- function(id, private = FALSE) {
   # Process the requested JSON
   res <- process_json(call)
 
+  # Process pagination
+  files <- process_pagination(res, config)
+
   files <- process_files(files)
 
   if (is.null(files)) {

--- a/R/files.R
+++ b/R/files.R
@@ -367,7 +367,7 @@ get_files_info <- function(id, private = FALSE) {
     idx <- which(files$kind == 'folder' & !files$processed)
     if (length(idx) == 0)
       break;
-    res <- lapply(files$href[idx], function(href) {
+    res <- lapply(files$folder_link[idx], function(href) {
       href <- paste0(href, '?kind=file&meta=')
       call <- httr::GET(href, config)
       tmp <- process_json(call)$data

--- a/R/files.R
+++ b/R/files.R
@@ -347,6 +347,7 @@ get_files_info <- function(id, private = FALSE) {
   # Creates a link to the OSF
   url_osf <- construct_link(request = paste0('nodes/', id, '/files/osfstorage/'))
 
+  # Calls the link
   call <- httr::GET(url_osf, config)
 
   # Process the requested JSON
@@ -355,11 +356,13 @@ get_files_info <- function(id, private = FALSE) {
   # Process pagination
   files <- process_pagination(res, config)
 
+  # Turn JSON into a data frame
   files <- process_files(files)
 
   if (is.null(files)) {
     return(NULL)
   }
+
   while (TRUE) {
     idx <- which(files$kind == 'folder' & !files$processed)
     if (length(idx) == 0)

--- a/R/files.R
+++ b/R/files.R
@@ -368,7 +368,6 @@ get_files_info <- function(id, private = FALSE) {
     if (length(idx) == 0)
       break;
     res <- lapply(files$folder_link[idx], function(href) {
-      href <- paste0(href, '?kind=file&meta=')
       call <- httr::GET(href, config)
       tmp <- process_json(call)$data
       process_files(tmp)

--- a/R/files.R
+++ b/R/files.R
@@ -344,7 +344,9 @@ get_files_info <- function(id, private = FALSE) {
     }))
   }
 
-  url_osf <- construct_link_files(id = id, request = '?meta=')
+  # Creates a link to the OSF
+  url_osf <- construct_link(request = paste0('nodes/', id, '/files/osfstorage/'))
+
   call <- httr::GET(url_osf, config)
   files <- process_json(call)$data
   files <- process_files(files)

--- a/R/files.R
+++ b/R/files.R
@@ -369,7 +369,7 @@ get_files_info <- function(id, private = FALSE) {
       break;
     res <- lapply(files$folder_link[idx], function(href) {
       call <- httr::GET(href, config)
-      tmp <- process_json(call)$data
+      tmp <- process_json(call)
       process_files(tmp)
     })
     files$processed <- TRUE

--- a/R/files.R
+++ b/R/files.R
@@ -363,6 +363,11 @@ get_files_info <- function(id, private = FALSE) {
     return(NULL)
   }
 
+  # Process all of the nested subfolders.
+  # This is done by calling each of the folder links and processing through
+  # the files. The loop begins with the top level folder, gets everything from
+  # its subfolders, and then repeats the loop through any further nested
+  # folders.
   while (TRUE) {
     idx <- which(files$kind == 'folder' & !files$processed)
     if (length(idx) == 0)

--- a/R/utils.R
+++ b/R/utils.R
@@ -79,6 +79,11 @@ process_pagination <- function(res, config) {
   # Use the first page of the returned data to get the next page link
   next_page_link <- res$links$`next`
 
+  # While next page link is not null, run loop
+  while(!is.null(next_page_link)) {
+
+  }
+
 }
 
 #' Create authorization config

--- a/R/utils.R
+++ b/R/utils.R
@@ -73,6 +73,8 @@ process_category <- function(category = '') {
 }
 
 process_pagination <- function(res, config) {
+  # Create variable to hold original page
+  combined_list <- res$data
 
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,6 +82,8 @@ process_pagination <- function(res, config) {
   # While next page link is not null, run loop
   while(!is.null(next_page_link)) {
 
+    # Call down the next page
+    new_page <- process_json(httr::GET(next_page_link, config))
   }
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -87,6 +87,9 @@ process_pagination <- function(res, config) {
 
     # Save new page next page link to the next page variable
     next_page_link <- new_page$links$`next`
+
+    # Combine current pages and new page
+    combined_list <- c(combined_list, new_page$data)
   }
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -84,6 +84,9 @@ process_pagination <- function(res, config) {
 
     # Call down the next page
     new_page <- process_json(httr::GET(next_page_link, config))
+
+    # Save new page next page link to the next page variable
+    next_page_link <- new_page$links$`next`
   }
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,6 +72,17 @@ process_category <- function(category = '') {
   }
 }
 
+#' Process Pagination
+#'
+#' Processes the paginated data returned by the OSF and returns a list with
+#' all of the pages combined.
+#'
+#' @param res The initial list return from the OSF API and run through
+#' `osfr::process_json()`. Must contain the links section.
+#' @param config The configuration used in the initial call to the OSF API.
+#'
+#' @return List of all of the pages from the API (including the input list).
+
 process_pagination <- function(res, config) {
   # Create variable to hold original page
   combined_list <- res$data

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,6 +72,10 @@ process_category <- function(category = '') {
   }
 }
 
+process_pagination <- function(res, config) {
+
+}
+
 #' Create authorization config
 #'
 #' @param login Boolean indicating whether login is required.

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,6 +76,9 @@ process_pagination <- function(res, config) {
   # Create variable to hold original page
   combined_list <- res$data
 
+  # Use the first page of the returned data to get the next page link
+  next_page_link <- res$links$`next`
+
 }
 
 #' Create authorization config

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,6 +92,8 @@ process_pagination <- function(res, config) {
     combined_list <- c(combined_list, new_page$data)
   }
 
+  # Return combined data
+  return(combined_list)
 }
 
 #' Create authorization config


### PR DESCRIPTION
This is a fix for issue #49, modifying `get_files_info()` to use the OSF API instead of WaterButler to populate the information about files. This should bypass WaterButler and allow the GUIDs to be populated properly.

I've created a new utility function, `process_pagination()`, that takes a list returned by the OSF API (processed by `process_json()`) and uses the next page links to cycle through all of the pages returned by the API. `process_pagination()` returns a list combining the output from all of the pages.

`get_files_info()` now calls directly to the nodes endpoint of the OSF API to get the file information. Since the API uses pagination, `process_pagination()` is used to extract all of the pages from the API. `get_files_info()` then processes all of the sub-folder information as before, though it now uses a link to the folders on the API instead of the WaterButler link.

The output of `get_files_info()` has the following changes:

* The `resource` and `content_type` columns have been removed as the OSF API does not provide that information.
* The `folder_link` column has been added and gives a link to folder on the OSF API.