### PR TITLE
Updating process_file_id() to reflect changes in OSF API

### DIFF
--- a/R/utils-waterbutler-api.R
+++ b/R/utils-waterbutler-api.R
@@ -63,5 +63,5 @@ process_file_id <- function(id, private = FALSE) {
     stop('Failed to retrieve information. Sure it is public?')
   }
 
-  return(res$data$links$download)
+  return(res$data$links$move)
 }


### PR DESCRIPTION
Due to changes in the OSF API, the link returned by the API for downloading a file is no longer a WaterButler link. With that change, `process_file_id()` doesn't return the proper link needed for the `move_files()` and `delete_files()` functions. To generate a WaterButler link for the file, the returned link has now been changed to the move link.

Here is a link for the [relevant changes to the OSF API](https://github.com/CenterForOpenScience/osf.io/pull/8107).