### PR TITLE
Removing unused arguments in recently update functions

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -22,7 +22,7 @@ upload_new_files <- function(id, path, name = NULL, href_hash = NULL) {
 
   config <- get_config(TRUE)
 
-  typ <- process_type(id, private = TRUE)
+  typ <- process_type(id)
   if (typ != 'nodes') {
     stop('Cannot upload new file if no node ID is specified.')
   }
@@ -67,7 +67,7 @@ upload_new_files <- function(id, path, name = NULL, href_hash = NULL) {
 #' }
 
 upload_files <- function(id, path, dest = NULL) {
-  type <- process_type(id, private = TRUE)
+  type <- process_type(id)
   subfolder_file <- FALSE
 
   if (is.null(dest)) {
@@ -178,7 +178,7 @@ upload_revised_files <- function(id, path) {
   }
 
   config <- get_config(TRUE)
-  typ <- process_type(id, private = TRUE)
+  typ <- process_type(id)
 
   if (typ == 'nodes') {
     stop('Specify an OSF id referring to a file.')
@@ -479,7 +479,7 @@ get_files_info <- function(id, private = FALSE) {
 path_file <- function(id, private = FALSE) {
   config <- get_config(private)
 
-  typ <- process_type(id, private = TRUE)
+  typ <- process_type(id)
 
   if (typ == 'nodes') {
     stop('Specify an OSF id referring to a file.')

--- a/R/files.R
+++ b/R/files.R
@@ -13,7 +13,7 @@ download_files <- function () {}
 #' @return Waterbutler URL
 #' @seealso \code{\link{upload_files}}, \code{\link{upload_revised_files}}
 
-upload_new_files <- function(id, path, name = NULL) {
+upload_new_files <- function(id, path, name = NULL, href_hash = NULL) {
   if (!file.exists(path)) {
     stop(sprintf('File %s does not exist on local machine.', path))
   } else if (is.null(name)) {

--- a/R/files.R
+++ b/R/files.R
@@ -112,7 +112,7 @@ upload_files <- function(id, path, dest = NULL) {
       upload_new_files(id, path, dest)
     } else if (!subfolder_file) {
       message('Revising file on OSF...')
-      upload_revised_files(id, path, dest, fi)
+      upload_revised_files(id, path)
     }
 
   } else if (type == 'files') {

--- a/R/folders.R
+++ b/R/folders.R
@@ -11,7 +11,7 @@ create_folder <- function(id, path, return = c("sub", "root", "all")[2]) {
 
   config <- get_config(TRUE)
 
-  typ <- process_type(id, private = TRUE)
+  typ <- process_type(id)
   if (typ != "nodes") {
     stop("Cannot create new folder if no node ID is specified.")
   }


### PR DESCRIPTION
I've removed the unused arguments in calls to `process_type()` and `upload_revised_files()` that were still there after recent changes to the functions. I also re-inserted an argument to `upload_new_files()` that was accidentally removed while resolving merge conflicts.