### PR TITLE
Get Nodes for Files

### DIFF
--- a/R/nodes.R
+++ b/R/nodes.R
@@ -48,7 +48,8 @@ get_nodes <- function(
   }
 
   if (files) {
-    call <- httr::GET(res$data$relationships$files$links$related$href, config)
+    # Change to access actual files id under guid tag within osfstorage
+    call <- httr::GET(paste0(res$data$relationships$files$links$related$href, "/osfstorage/"), config)
     res <- process_json(call)
   }
 


### PR DESCRIPTION
There are a number of changes here that you are welcome to if you want them, though some may be a bit tacky and aren't my changes. The main thing I am issuing the request for is `get_nodes` which currently returns "osfstorage" if you enter `files = TRUE`. I've changed this to go within "osfstorage".