### PR TITLE
Updating comments for clarity

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -118,7 +118,7 @@ upload_files <- function(id, path, dest = NULL) {
   } else {
     stop('Something odd happened.\n
          If the problem persists, consider issuing a bug report on
-         github.com/chartgerink/osfr')
+         github.com/CenterForOpenScience/osfr')
   }
 }
 

--- a/R/files.R
+++ b/R/files.R
@@ -72,16 +72,16 @@ upload_files <- function(id, path, dest = NULL) {
     dest <- basename(path)
   }
 
-  ## Here we need to check for 'nodes' then have another condition within nodes. see `idx_folder`
+  ## Check if id type is 'nodes'
   if (type == "nodes") {
 
     fi <- get_files_info(id, private = TRUE)
 
-    # Added check to see if 'fi' is NULL. If no file exists in a component, this not run.
+    # Check to see if 'fi' is NULL. If no file exists in a component, this not run
     if (!is.null(fi)) {
       idx <- which(fi$materialized == pre_slash(dest))
 
-      # check for destination value subfolder
+      # Check for destination value subfolder
       if (!is.null(dest)) {
         fi_folder <- paste0(dirname(dest), "/")
         dest_fname <- basename(dest)
@@ -90,7 +90,7 @@ upload_files <- function(id, path, dest = NULL) {
 
         hash_folder <- paste0(basename(fi[idx_folder, "href"]), "/")
 
-        # check for subfolder created and file not there.
+        # Check if subfolder created and file not there
         if (length(idx) != 1 & length(idx_folder) == 1) {
           message(paste0('Creating new file on OSF in subfolder ', fi_folder  ,' ...'))
           upload_new_files(id, path, dest_fname, href_hash = hash_folder)
@@ -101,10 +101,9 @@ upload_files <- function(id, path, dest = NULL) {
         }
       }
     }
-    ### End addition
 
-    # changed condition for new file creation
-
+    # Upload new file if file does not exist in directory and it is not a
+    # subfolder file. Otherwise, upload revised file.
     if (length(idx) != 1 & !subfolder_file) {
       message('Creating new file on OSF...')
       upload_new_files(id, path, dest)
@@ -118,8 +117,8 @@ upload_files <- function(id, path, dest = NULL) {
     upload_revised_files(id, path)
   } else {
     stop('Something odd happened.\n
-          If the problem persists, consider issuing a bug report on
-          github.com/chartgerink/osfr')
+         If the problem persists, consider issuing a bug report on
+         github.com/chartgerink/osfr')
   }
 }
 

--- a/R/folders.R
+++ b/R/folders.R
@@ -33,7 +33,9 @@ create_folder <- function(id, path, return = c("sub", "root", "all")[2]) {
     stop("Unsuccessful folder creation.")
   }
 
-## Addition to create subfolders if root folder was already created
+  # If root folder creation is successful, create link to the new folder.
+  # If unsuccessful, check to see if the folder already exists and save link
+  # for the creation of subfolders.
 
   if (call$status_code == 201) {
     res <- process_json(call)
@@ -44,11 +46,6 @@ create_folder <- function(id, path, return = c("sub", "root", "all")[2]) {
     fi_row <- which(fi$materialized == paste0(pre_slash(path_root), "/"))
     res_root_link <- paste0(fi[fi_row, "href"],'?kind=folder')
   }
-
-### end root folder addition check.
-
-
-
 
   # Create subfolders and keep the url json information for each creation.
 
@@ -72,8 +69,10 @@ create_folder <- function(id, path, return = c("sub", "root", "all")[2]) {
   }
   names(res_sub) = path_sub
 
-  # This if else patch depends on the return statement.  Wasn't sure which to default.  So added a return value in
-  # function that can prescribe which is returned.
+  # Check the return parameter. If set to "all", return links to all of new
+  # folders created. If set to "root", return only the link to the lowest level
+  # folder created. If set to "sub", return the links of all of the subfolders
+  # created.
 
   if(return == "all") {
     res_sub_links <- lapply(res_sub, function(x) x$data$links$new_folder)


### PR DESCRIPTION
This PR updates the comments in `upload_files()` and `create_folder()` for additional clarity. It also updates the link given in the error response of `upload_files()` to reflect changes in the repository.