### PR TITLE
Fix for path_file()

### DIFF
--- a/R/files.R
+++ b/R/files.R
@@ -543,6 +543,11 @@ path_file <- function(id, private = FALSE) {
     res <- process_json(call)
   }
 
+  # Check if returned information is of type "files"
+  if (res$data$type != "files") {
+    stop("Please specify an OSF id referring to a file.")
+  }
+
   return(res$data$links$download)
 }
 

--- a/R/files.R
+++ b/R/files.R
@@ -543,10 +543,6 @@ path_file <- function(id, private = FALSE) {
     res <- process_json(call)
   }
 
-  if (!call$status_code == 200) {
-    stop('Failed. Are you sure you have access to the file?')
-  }
-
   return(res$data$links$download)
 }
 

--- a/R/files.R
+++ b/R/files.R
@@ -497,15 +497,18 @@ get_files_info <- function(id, private = FALSE) {
 #' Get file download link for the latest version of a file (for direct reading)
 #'
 #' @param id Specify the file id (osf.io/XXXXX)
-#' @param private Boolean to specify whether file is private
+#' @param view_only Specify the view-only link (string)
 #'
 #' @return Return download link (online)
 #' @examples
 #' \dontrun{
 #' read.csv(path_file("5z2bh"))
+#' read.csv(path_file('852dp', 'view_only_test_file.csv',
+#'   view_only = 'https://osf.io/jy9gm/?view_only=a500051f59b14a988415f08539dbd491'))
 #' }
 #' @importFrom utils tail
 #' @export
+#' @seealso \code{\link{download_files}}
 
 path_file <- function(id, view_only = NULL) {
   config <- list()

--- a/R/files.R
+++ b/R/files.R
@@ -507,7 +507,7 @@ get_files_info <- function(id, private = FALSE) {
 #' @importFrom utils tail
 #' @export
 
-path_file <- function(id, private = FALSE) {
+path_file <- function(id, view_only = NULL) {
   config <- list()
 
   url_osf <- construct_link(paste0('guids/', id))

--- a/R/files.R
+++ b/R/files.R
@@ -508,7 +508,7 @@ get_files_info <- function(id, private = FALSE) {
 #' @export
 
 path_file <- function(id, private = FALSE) {
-  config <- get_config(private)
+  config <- list()
 
   typ <- process_type(id)
 

--- a/R/files.R
+++ b/R/files.R
@@ -503,7 +503,7 @@ get_files_info <- function(id, private = FALSE) {
 #' @examples
 #' \dontrun{
 #' read.csv(path_file("5z2bh"))
-#' read.csv(path_file('852dp', 'view_only_test_file.csv',
+#' read.csv(path_file('852dp',
 #'   view_only = 'https://osf.io/jy9gm/?view_only=a500051f59b14a988415f08539dbd491'))
 #' }
 #' @importFrom utils tail

--- a/R/files.R
+++ b/R/files.R
@@ -360,6 +360,11 @@ download_files <- function(id, path = NULL, view_only = NULL, version = NULL) {
     res <- process_json(call)
   }
 
+  # Check if returned information is of type "files"
+  if (res$data$type != "files") {
+    stop("Please specify an OSF id referring to a file.")
+  }
+
   # Determine the file name to save the file as.
   # If no path is provided, use the OSF file name.
   # If a path is provided, determine if the path is just a folder path or if

--- a/R/files.R
+++ b/R/files.R
@@ -510,17 +510,9 @@ get_files_info <- function(id, private = FALSE) {
 path_file <- function(id, private = FALSE) {
   config <- list()
 
-  typ <- process_type(id)
-
-  if (typ == 'nodes') {
-    stop('Specify an OSF id referring to a file.')
-  } else if (typ == 'files') {
-    url_osf <- construct_link(paste0('guids/', id))
-    call <- httr::GET(url_osf, config)
-    res <- process_json(call)
-    } else {
-    stop('Unknown error occurred. Please file issue on GitHub.')
-  }
+  url_osf <- construct_link(paste0('guids/', id))
+  call <- httr::GET(url_osf, config)
+  res <- process_json(call)
 
   if (!call$status_code == 200) {
     stop('Failed. Are you sure you have access to the file?')

--- a/man/path_file.Rd
+++ b/man/path_file.Rd
@@ -20,7 +20,7 @@ Get file download link for the latest version of a file (for direct reading)
 \examples{
 \dontrun{
 read.csv(path_file("5z2bh"))
-read.csv(path_file('852dp', 'view_only_test_file.csv',
+read.csv(path_file('852dp',
   view_only = 'https://osf.io/jy9gm/?view_only=a500051f59b14a988415f08539dbd491'))
 }
 }

--- a/man/path_file.Rd
+++ b/man/path_file.Rd
@@ -4,12 +4,12 @@
 \alias{path_file}
 \title{Get file download link for the latest version of a file (for direct reading)}
 \usage{
-path_file(id, private = FALSE)
+path_file(id, view_only = NULL)
 }
 \arguments{
 \item{id}{Specify the file id (osf.io/XXXXX)}
 
-\item{private}{Boolean to specify whether file is private}
+\item{view_only}{Specify the view-only link (string)}
 }
 \value{
 Return download link (online)
@@ -20,5 +20,10 @@ Get file download link for the latest version of a file (for direct reading)
 \examples{
 \dontrun{
 read.csv(path_file("5z2bh"))
+read.csv(path_file('852dp', 'view_only_test_file.csv',
+  view_only = 'https://osf.io/jy9gm/?view_only=a500051f59b14a988415f08539dbd491'))
 }
+}
+\seealso{
+\code{\link{download_files}}
 }


### PR DESCRIPTION
This addresses the issue raised in issue #68. The `path_file()` function has been updated to reflect the changes in `download_files()`, allowing `path_file()` to automatically check if the file is public and return the download link. If the file is not public, `path_file()` checks to see if a view-only link is available and returns the download link with the appropriate view-only link attached. If there is no view-only link, `path_file()` assumes the file is private and uses the users login information to retrieve the download link.

This pull request also updates `download_files()` to include a check of the OSF id type. If the id being downloaded is not of type "files" an error will be generated.