### PR TITLE
v0.2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,9 @@ jobs:
   - r: oldrel
   - r: devel
   - r: release
-    after_success:
-    - Rscript -e 'covr::codecov()'
-    before_cache:
-    - Rscript -e 'remotes::install_cran("pkgdown")'
-    after_failure:
-    - cat osfr.log
-    before_deploy:
-    - Rscript -e 'remotes::install_cran("pkgdown")'
+    after_success: Rscript -e 'covr::codecov()'
+    after_failure: cat osfr.log
+    before_deploy: Rscript -e 'remotes::install_cran("pkgdown")'
     deploy:
       on:
         branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: r
-sudo: false
+os: linux
 cache: packages
-
-
-r_packages:
-  - devtools
-
-install:
-- R -e 'install.packages("remotes")'
-- R -e 'remotes::install_deps(dep = T)'
 
 script:
 - R CMD build . --no-build-vignettes
@@ -25,7 +17,8 @@ jobs:
     - Rscript -e 'remotes::install_cran("pkgdown")'
     after_failure:
     - cat osfr.log
-
+    before_deploy:
+    - Rscript -e 'remotes::install_cran("pkgdown")'
     deploy:
       on:
         branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ jobs:
       on:
         branch: master
       provider: script
-      script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE)'
+      script: Rscript -e 'pkgdown::deploy_site_github(verbose = TRUE, tarball = dir(pattern = "tar.gz$"))'
       skip_cleanup: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osfr
 Title: R Interface to OSF
-Version: 0.2.6
+Version: 0.2.6.1
 Authors@R: c(
     person("Aaron", "Wolen",, "aaron@wolen.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2542-2202")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * New approach uses a file manifest to compare local and remote files
 * We now search for conflicting remote files within each directory queued for upload, this avoids the issue reported in (#108, thanks @tpyork)
 
+## osfr 0.2.6.1
+
+* Fix pkgdown deployment
 
 # osfr 0.2.5
 

--- a/R/osf_mkdir.R
+++ b/R/osf_mkdir.R
@@ -1,9 +1,10 @@
 #' Create directories on OSF
 #'
-#' Use `osf_mkdir()` to create a new directory on OSF. Directories can be added
-#' to projects, components, or nested within existing directories on OSF. If
-#' `path` contains multiple directories (e.g., `"data/rawdata"`) the
-#' intermediate-level directories will be created if needed.
+#' Use `osf_mkdir()` to add new directories to projects, components, or nested
+#' within existing OSF directories. If `path` contains multiple directory
+#' levels (e.g., `"data/rawdata"`) the intermediate-level directories are
+#' created automatically. If the directory you're attempting to create already
+#' exists on OSF it will be silently ignored and included in the output.
 #'
 #' @param x One of the following:
 #'   * An [`osf_tbl_node`] with a single OSF project or component.


### PR DESCRIPTION
Fixes pkgdown deployment. 

The custom `script` in my travis config prevents `pkgdown::deploy_site_github()` from discovering the built tarball. I verified the tarball file is present during deployment. Explicitly defining the `PKG_TARBALL` environment variable also didn't help. The only workaround I could find was to manually pass the file to the `tarball` argument.