### PR TITLE
Improve authentication and token error handling

### DIFF
--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,0 +1,39 @@
+# Verify roxygen-generated docs are up to date
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: document.yaml
+
+permissions: read-all
+
+jobs:
+  document:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2
+          needs: roxygen2
+
+      - run: roxygen2::roxygenise()
+        shell: Rscript {0}
+
+      - name: Check for documentation differences
+        run: |
+          git diff --exit-code -- man/ NAMESPACE || {
+            echo "::error::Generated docs are out of date. Run devtools::document() and commit the results."
+            exit 1
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 Meta
 doc
+*.Rcheck/
+*.tar.gz
 # History files
 .Rhistory
 .Rapp.history

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,5 +51,5 @@ Suggests:
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.3.3
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: osfr
 Title: Interface to the 'Open Science Framework' ('OSF')
-Version: 0.2.9.9000
+Version: 0.2.9.9001
 Authors@R: c(
     person("Aaron", "Wolen",, "aaron@wolen.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-2542-2202")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,14 @@
 # osfr (development version)
 
+## Improvements
+
+* Authentication errors (401/403) now include troubleshooting hints.
+* Non-auth API errors now include the detail message from the API response.
+* `osf_auth()` warns if the provided PAT has an unexpected length.
+
 ## Fixes
 
 * Fixed the `Accept` header name in `.build_client()`. The header was incorrectly set as `Accept-Header`, which meant API version pinning never actually worked.
-
 * Fixed `osf_mv()` and `osf_cp()` failing with an uninformative error when a conflict is encountered. Waterbutler dropped the `code` field from conflict (409) responses, which prevented the error message from being extracted and surfaced correctly.
 
 ## API compatibility

--- a/R/api-endpoints-osf.R
+++ b/R/api-endpoints-osf.R
@@ -100,7 +100,7 @@
 #' @param n_max max number of pages to retrieve from the API
 #' @param query a list of query params to include in the call. This is necessary
 #'   for filtering.
-#' @param verbose Logical passed to [`.osf_paginated_request()`]
+#' @param verbose Logical passed to `.osf_paginated_request()`
 #' @return An entity collection with entities sorted by `date_modified`
 #' @references
 #' https://developer.osf.io/#operation/nodes_list

--- a/R/osf_auth.R
+++ b/R/osf_auth.R
@@ -78,9 +78,24 @@ osf_auth <- function(token = NULL) {
   if (is.null(token)) {
     warning("No PAT found. See ?osf_auth for help")
   } else {
+    validate_pat_format(token)
     message("Registered PAT from the ", source)
   }
 
   options(osfr.pat = token)
   invisible(token)
+}
+
+#' Warn if a PAT has an unexpected format
+#'
+#' @param pat A personal access token string
+#' @noRd
+validate_pat_format <- function(pat) {
+  if (nchar(pat) != 70) {
+    warning(
+      "PAT has an unexpected length (", nchar(pat), " chars, expected 70). ",
+      "Verify your token was copied correctly.",
+      call. = FALSE
+    )
+  }
 }

--- a/R/osf_tbl.R
+++ b/R/osf_tbl.R
@@ -72,15 +72,19 @@ new_osf_tbl <- function(x, subclass = NULL) {
 }
 
 # expects a list, where each item is OSF entity represented as a list
+#' @noRd
 as_osf_tbl <- function(x, subclass = NULL) UseMethod("as_osf_tbl")
 
+#' @noRd
 as_osf_tbl.default <- function(x, subclass = NULL)
   abort("No methods available to coerce this object into an osf_tbl")
 
 # nolint start
+#' @noRd
 as_osf_tbl.data.frame <- function(x, subclass = NULL) new_osf_tbl(x, subclass)
 # nolint end
 
+#' @noRd
 as_osf_tbl.list <- function(x, subclass = NULL) {
 
   # handle empty lists returned by e.g. .osf_node_children() for childless nodes

--- a/R/utils-api-responses.R
+++ b/R/utils-api-responses.R
@@ -78,7 +78,25 @@ process_response <- function(res) {
 #' @param x list returned by \code{process_response()}
 #' @noRd
 raise_error <- function(x) {
-  if (!is.null(x$errors)) http_error(x$status_code, x$errors[[1]]$detail)
+  if (is.null(x$errors)) return(invisible())
+
+  detail <- x$errors[[1]]$detail
+  code <- x$status_code
+
+  if (code %in% c(401L, 403L)) {
+    auth_hint <- paste0(
+      "Authentication failed (HTTP ", code, ").",
+      if (!is.null(detail) && nzchar(detail)) paste0("\n\n", detail, "."),
+      "\n\nTroubleshooting steps:",
+      "\n- Verify your PAT is correct with Sys.getenv(\"OSF_PAT\")",
+      "\n- Generate a new token at https://osf.io/settings/tokens/",
+      "\n- Re-authenticate with osf_auth()",
+      "\n- Ensure your token has the required scopes for this operation\n\n"
+    )
+    stop(auth_hint, call. = FALSE)
+  }
+
+  http_error(code, detail)
 }
 
 # Convert datetime attributes to POSIXct objects

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,12 +33,14 @@ prepend_version <- function(path, version) {
 
 #' Stop execution with HTTP status code
 #' @param code HTTP status code
-#' @inheritParams base::stop
+#' @param detail Optional detail message from the API response
 #' @noRd
-http_error <- function(code, ...) {
-  args <- list(...)
-  msg <- sprintf("\n       HTTP status code %i.", code)
-  stop(args, msg, call. = FALSE)
+http_error <- function(code, detail = NULL) {
+  msg <- sprintf("HTTP status code %i.", code)
+  if (!is.null(detail) && nzchar(detail)) {
+    msg <- paste0(msg, "\n", detail)
+  }
+  stop(msg, call. = FALSE)
 }
 
 #' Inform user the API request failed and will be retried

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,10 +1,5 @@
 library(vcr)
 
-# Cassettes are recorded against the test server so ensure OSF_SERVER is set
-if (!nzchar(Sys.getenv("OSF_SERVER"))) {
-  withr::local_envvar(OSF_SERVER = "test", .local_envir = teardown_env())
-}
-
 cassette_dir <- function(x) {
   vcr::vcr_test_path("cassettes", x)
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,4 @@
+# Cassettes are recorded against the test server so ensure OSF_SERVER is set
+if (!nzchar(Sys.getenv("OSF_SERVER"))) {
+  withr::local_envvar(OSF_SERVER = "test", .local_envir = teardown_env())
+}

--- a/tests/testthat/test-auth-errors.R
+++ b/tests/testthat/test-auth-errors.R
@@ -1,0 +1,71 @@
+# raise_error() auth messages -----------------------------------------------
+
+test_that("raise_error() provides hint for 401 responses", {
+  err <- list(
+    errors = list(list(detail = "Authentication credentials were not provided.")),
+    status_code = 401L
+  )
+  expect_error(
+    raise_error(err),
+    "Authentication failed"
+  )
+  expect_error(
+    raise_error(err),
+    "osf_auth"
+  )
+})
+
+test_that("raise_error() provides hint for 403 responses", {
+  err <- list(
+    errors = list(list(detail = "You do not have permission to perform this action.")),
+    status_code = 403L
+  )
+  expect_error(
+    raise_error(err),
+    "Authentication failed"
+  )
+  expect_error(
+    raise_error(err),
+    "required scopes"
+  )
+})
+
+test_that("raise_error() includes API detail in auth error messages", {
+  detail <- "Authentication credentials were not provided."
+  err <- list(
+    errors = list(list(detail = detail)),
+    status_code = 401L
+  )
+  expect_error(
+    raise_error(err),
+    detail,
+    fixed = TRUE
+  )
+})
+
+test_that("raise_error() passes through non-auth errors to http_error()", {
+  err <- list(
+    errors = list(list(detail = "Not found.")),
+    status_code = 404L
+  )
+  expect_error(
+    raise_error(err),
+    "HTTP status code 404"
+  )
+})
+
+test_that("raise_error() includes detail in non-auth error messages", {
+  err <- list(
+    errors = list(list(detail = "Not found.")),
+    status_code = 404L
+  )
+  expect_error(
+    raise_error(err),
+    "Not found.",
+    fixed = TRUE
+  )
+})
+
+test_that("raise_error() is silent when there are no errors", {
+  expect_silent(raise_error(list(data = list())))
+})

--- a/tests/testthat/test-authentication.R
+++ b/tests/testthat/test-authentication.R
@@ -12,7 +12,7 @@ test_that("osf_auth() defines osfr.pat from token arg", {
   withr::local_options(osfr.pat = NULL)
 
   expect_message(
-    osf_auth("fake_token"),
+    suppressWarnings(osf_auth("fake_token")),
     "Registered PAT from the provided token"
   )
   expect_equal("fake_token", getOption("osfr.pat"))
@@ -24,8 +24,30 @@ test_that("osf_auth() defines osfr.pat from OSF_PAT", {
   withr::local_options(osfr.pat = NULL)
 
   expect_message(
-    osf_auth(),
+    suppressWarnings(osf_auth()),
     "Registered PAT from the OSF_PAT environment variable"
   )
   expect_equal("fake_token", getOption("osfr.pat"))
+})
+
+
+# Token format validation -------------------------------------------------
+
+test_that("osf_auth() warns on unexpected token length", {
+  withr::local_envvar(OSF_PAT = NA)
+  withr::local_options(osfr.pat = NULL)
+
+  expect_warning(
+    suppressMessages(osf_auth("short_token")),
+    "unexpected length"
+  )
+})
+
+test_that("osf_auth() does not warn for 70-character token", {
+  withr::local_envvar(OSF_PAT = NA)
+  withr::local_options(osfr.pat = NULL)
+
+  expect_no_warning(
+    suppressMessages(osf_auth(strrep("a", 70)))
+  )
 })


### PR DESCRIPTION
## Changes

- Add actionable troubleshooting hints for 401/403 API errors
- Validate PAT expected length during `osf_auth()` registration
- Clean up `http_error()` to include API detail messages